### PR TITLE
Add support for fetch name being a URL or containing spaces

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -12,6 +12,7 @@ import bpy
 import os
 import urllib.request
 import zipfile
+import re
 from bpy.props import StringProperty, EnumProperty, FloatProperty
 from pathlib import Path
 
@@ -44,7 +45,11 @@ class MATERIAL_OT_fetch_and_create(bpy.types.Operator):
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
-        material_name = context.scene.ambientcg_material_name
+        input_val = context.scene.ambientcg_input_string
+
+        # Match URL or string for valid id, selects just the material name / id
+        # Also removes spaces to users can just copy the name on the webpage 
+        material_name = re.search(r"(?:id=)?([A-Za-z0-9]+)$", input_val.replace(" ", "")).group(1)
         resolution = context.scene.ambientcg_resolution
 
         url = f"https://ambientcg.com/get?file={material_name}_{resolution}-PNG.zip"
@@ -198,7 +203,7 @@ class MATERIAL_PT_ambientcg_fetcher(bpy.types.Panel):
         layout = self.layout
         scene = context.scene
 
-        layout.prop(scene, "ambientcg_material_name", text="Material Name")
+        layout.prop(scene, "ambientcg_input_string", text="Material Name")
         layout.prop(scene, "ambientcg_resolution", text="Resolution")
         layout.prop(scene, "ambientcg_projection", text="Projection")
 
@@ -219,9 +224,9 @@ classes = (
 def register():
     for cls in classes:
         bpy.utils.register_class(cls)
-    bpy.types.Scene.ambientcg_material_name = StringProperty(
+    bpy.types.Scene.ambientcg_input_string = StringProperty(
         name="Material Name",
-        description="Name of the AmbientCG material (e.g., Rock035)",
+        description="Name of the AmbientCG material (e.g., Rock035)\nOr URL like: https://ambientcg.com/view?id=Tiles141",
         default="Rock035",
     )
     bpy.types.Scene.ambientcg_resolution = EnumProperty(
@@ -257,7 +262,7 @@ def register():
 def unregister():
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)
-    del bpy.types.Scene.ambientcg_material_name
+    del bpy.types.Scene.ambientcg_input_string
     del bpy.types.Scene.ambientcg_resolution
     del bpy.types.Scene.ambientcg_projection
     del bpy.types.Scene.ambientcg_blend


### PR DESCRIPTION
Makes the following cases (and more) valid:

---
### Spaces:

<img width="406" height="170" alt="image" src="https://github.com/user-attachments/assets/4eeb4b08-ab2b-4f35-825c-55e7ba21d82a" />

---
### URLs: 

<img width="408" height="142" alt="image" src="https://github.com/user-attachments/assets/c4051816-ebc7-41fa-a39c-e7c959b3e1fb" />

---

These get turned into the common material name, in this case `Tiles141` as expected.